### PR TITLE
"showDirFiles" might create unnecessary null entries in $listing.

### DIFF
--- a/listing.php
+++ b/listing.php
@@ -109,8 +109,8 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 			// Only list files/directories that are not designated as off-limits
 			$access = ($isDir) ? $rep->hasReadAccess($path.$file, true)
 												 : $accessToThisDir;
-			$listvar = &$listing[$index];
 			if ($access) {
+				$listvar = &$listing[$index];
 				$listvar['rowparity'] = $index % 2;
 
 				if ($isDir) {


### PR DESCRIPTION
"showDirFiles" always created a new entry in the structure containig the dirs and files to render, even if some dir was not accessible for the current user because a lack of permissions. While those entries were null/undef or such, during rendering the template the data of the last non-null entry was used to render all the null-entries as well. This resulted in wrong HTML output of course.